### PR TITLE
java frameworks: start.sh as entrypoint, support more complex commands

### DIFF
--- a/frameworks/java7/Dockerfile
+++ b/frameworks/java7/Dockerfile
@@ -30,3 +30,5 @@ RUN chmod +x /usr/local/bin/start.sh
 
 ENV HOME  /
 WORKDIR /
+
+ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/frameworks/java7/start.sh
+++ b/frameworks/java7/start.sh
@@ -16,7 +16,7 @@ maintenance(){
 
 trap 'maintenance && sleep 2 && kill -TERM $PID' TERM INT
 
-"$@" &
+eval "$@" &
 PID=$!
 wait $PID
 trap - TERM INT

--- a/frameworks/java8/Dockerfile
+++ b/frameworks/java8/Dockerfile
@@ -30,3 +30,5 @@ RUN chmod +x /usr/local/bin/start.sh
 
 ENV HOME  /
 WORKDIR /
+
+ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/frameworks/java8/start.sh
+++ b/frameworks/java8/start.sh
@@ -16,7 +16,7 @@ maintenance(){
 
 trap 'maintenance && sleep 2 && kill -TERM $PID' TERM INT
 
-"$@" &
+eval "$@" &
 PID=$!
 wait $PID
 trap - TERM INT


### PR DESCRIPTION
By default signals aren't properly passed to child procs (/bin/sh).
To avoid this we set our start.sh as entry point (/bin/bash script).
When using with marathon/mesos, pass additional command as 'args' parameter.
Mesos automatically wraps command passed via cmd parameter in /bin/sh -c ''.