### PR TITLE
haproxy consul-template fix

### DIFF
--- a/infrastructure/haproxy/in.conf
+++ b/infrastructure/haproxy/in.conf
@@ -37,9 +37,10 @@ listen stats :81
 frontend http-in
     bind *:80
 
-{{range services}}{{$service:=.Name}}{{range .Tags}}{{if or (eq . "webapp") (eq . "haproxy")}}
-    acl acl_{{$service}} hdr(host) -i {{$service}}.service.consul
-    use_backend backend_{{$service}} if acl_{{$service}}
+{{range services}}{{range $tag, $services := service .Name|byTag}}{{if or (eq $tag "webapp") (eq $tag "haproxy")}}    #{{$service_name := (index $services 0).Name}}{{$service_name}}
+    acl acl_{{$service_name}} hdr(host) -i {{$service_name}}.service.consul
+    use_backend backend_{{$service_name}} if acl_{{$service_name}}
+
 {{end}}{{end}}{{end}}
 {{range services}}{{range $tag, $services := service .Name|byTag}}{{if or (eq $tag "webapp") (eq $tag "haproxy")}}{{$service_name := (index $services 0).Name}}
     backend backend_{{$service_name}}


### PR DESCRIPTION
don't route to backends that won't be configured due to all services failing